### PR TITLE
tox: Suppress pep8 format warning

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+filterwarnings = ignore:.*pep8.*


### PR DESCRIPTION
This fixes a CI warning about how some dependencies construct pep8 objects