### PR TITLE
Stop using the Coveralls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,13 +21,8 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
       - name: Install Dependencies
-        run: pip install tox coveralls
+        run: pip install tox
       - name: Run schemas tests
         run: ./tests/schemas/run.sh
       - name: Run Tox
         run: tox -e py
-      - name: Coverage
-        run: coveralls
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 ![Tests](https://github.com/UpdateHub/package-schema/workflows/CI/badge.svg)
-[![Coverage Status](https://coveralls.io/repos/github/UpdateHub/package-schema/badge.svg?branch=master)](https://coveralls.io/github/UpdateHub/package-schema?branch=master)
 [![PyPI](https://img.shields.io/pypi/v/updatehub-package-schema)](https://pypi.python.org/pypi/package-schema/)
 
 # updatehub-package-schema


### PR DESCRIPTION
The coveralls does not make much sense as there no much code to test but
instead error cases. This fixes the CI failure we are facing.

Signed-off-by: Otavio Salvador <otavio@ossystems.com.br>